### PR TITLE
tmp patch

### DIFF
--- a/src/pyflex/window_selector.py
+++ b/src/pyflex/window_selector.py
@@ -640,8 +640,8 @@ class WindowSelector(object):
             i_left = internal_maxima[0]
             i_right = internal_maxima[-1]
 
-            delta_left = i_left - win.left
-            delta_right = win.right - i_right
+            delta_left = int(i_left) - win.left
+            delta_right = win.right - int(i_right)
 
             # check condition
             if delta_left > time_decay_left:


### PR DESCRIPTION
with python 2.7.8

TypeError                                 Traceback (most recent call last)
<ipython-input-95-deb7a896443d> in <module>()
     78 
     79 
---> 80 delta_right = win.right - i_right

/Users/casarotti/canopy/User/lib/python2.7/site-packages/future-0.11.2-py2.7.egg/future/builtins/types/newint.pyc in **sub**(self, other)
     95 
     96     def **sub**(self, other):
---> 97         return newint(super(newint, self).**sub**(other))
     98 
     99     def **rsub**(self, other):

/Users/casarotti/canopy/User/lib/python2.7/site-packages/future-0.11.2-py2.7.egg/future/builtins/types/newint.pyc in **new**(cls, x, base)
     77             except:
     78                 raise TypeError("newint argument must be a string or a number, not '{0}'".format(
---> 79                                     type(val)))
     80 
     81 

TypeError: newint argument must be a string or a number, not '<type 'NotImplementedType'>'
